### PR TITLE
feat: Allow using emptyDir instead of hostPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ In a cloud environment, it may be used to optimize disk usage and IOPS costs. Fo
 ## Requirements
 
 * Kubernetes 1.6+
-* RBAC enabled
 * PSP not enabled
 * Helm
+
+It is highly recommended that you enable RBAC.
 
 ## Installation
 
@@ -30,6 +31,14 @@ The following defaults are used. You can override them with `--set variable=valu
 
 Default: `quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8`
 
+## `rbac.enabled`
+
+To disable RBAC support, set this to false. It is recommended that you use RBAC
+and leave this enabled. However, you can disable it to create your own RoleBinding
+and Role.
+
+Default: true
+
 ### `provisionerName`
 
 Default: `local.net/nfs`
@@ -40,7 +49,18 @@ Default: `local-nfs`
 
 ### `hostPath`
 
+If this is empty, no local storage will be used, making this completely emphemeral.
+
 Default: `/srv/nfs-provisioner`
+
+### `useTmpfs`
+
+If hostPath is empty and this is set to true, the NFS server will use memory-based
+tmpfs storage instead of allocating disk. This is very fast and very volatile, and
+has the additional risk of consuming cluster memory resources. It will not persist
+across a node restart.
+
+Default: false
 
 ### `defaultClass`
 
@@ -52,7 +72,7 @@ Default: `false`
 
 * [ ] Dynamically name resources (allow to run multiple provisioners simultaneously)
 * [ ] Support storage volume types other than `hostPath` (e.g. other persistent volumes)
-* [ ] Support clusters without RBAC?
+* [X] Support clusters without RBAC?
 * [ ] Support PSP?
 
 PRs are welcome.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Default: `false`
 
 * [ ] Dynamically name resources (allow to run multiple provisioners simultaneously)
 * [ ] Support storage volume types other than `hostPath` (e.g. other persistent volumes)
-* [X] Support clusters without RBAC?
 * [ ] Support PSP?
 
 PRs are welcome.

--- a/charts/nfs-provisioner/templates/rbac.yaml
+++ b/charts/nfs-provisioner/templates/rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: nfs-provisioner
+{{ if .Values.rbac.enabled }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -40,3 +41,4 @@ roleRef:
   kind: ClusterRole
   name: nfs-provisioner-runner
   apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/charts/nfs-provisioner/templates/statefulset-sa.yaml
+++ b/charts/nfs-provisioner/templates/statefulset-sa.yaml
@@ -71,5 +71,12 @@ spec:
               mountPath: /export
       volumes:
         - name: export-volume
+{{ if .Values.hostPath }}
           hostPath:
             path: "{{ .Values.hostPath }}"
+{{ else if .Values.useTmpfs }}
+          emptyDir:
+            medium: Memory
+{{ else }}
+          emptyDir: {}
+{{ end }}

--- a/charts/nfs-provisioner/values.yaml
+++ b/charts/nfs-provisioner/values.yaml
@@ -21,4 +21,3 @@ useTmpfs: false
 # Toggle RBAC on and off
 rbac:
   enabled: true
-

--- a/charts/nfs-provisioner/values.yaml
+++ b/charts/nfs-provisioner/values.yaml
@@ -1,6 +1,6 @@
 image: "quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8"
 
-# Seet the provisioner name for the nfs provisioner.
+# Set the provisioner name for the nfs provisioner.
 provisionerName: "local.net/nfs"
 
 # The name of the storage class that will be provided by NFS.

--- a/charts/nfs-provisioner/values.yaml
+++ b/charts/nfs-provisioner/values.yaml
@@ -1,5 +1,24 @@
 image: "quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8"
+
+# Seet the provisioner name for the nfs provisioner.
 provisionerName: "local.net/nfs"
+
+# The name of the storage class that will be provided by NFS.
 storageClass: "local-nfs"
-hostPath: "/srv/nfs-provisioner"
+
+# Set the NFS provisioner to be the default storage class.
 defaultClass: false
+
+# If hostPath is empty, no hostPath volume is mounted. Instead, the server
+# is backed by an emptyDir.
+hostPath: "/srv/nfs-provisioner"
+
+# If hostPath is empty and this is true, the emptyDir will mount a tmpfs instead
+# of using local storage. This is vey fast and very volatile, but might be useful
+# for things like caches and temporary workspaces.
+useTmpfs: false
+
+# Toggle RBAC on and off
+rbac:
+  enabled: true
+

--- a/examples/pvc.yaml
+++ b/examples/pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: myclaim
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Mi
+  storageClassName: local-nfs


### PR DESCRIPTION
This adds some configuration options to allow the NFS server to back to
an empty dir (even as a tmpfs) instead of a hostPath.

Along the way, I added simple logic to turn off RBAC, and added an
example.