### PR TITLE
Allow Configuring a PVC for the provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,26 +47,54 @@ Default: `local.net/nfs`
 
 Default: `local-nfs`
 
-### `hostPath`
+### `provisionerVolume`
 
-If this is empty, no local storage will be used, making this completely emphemeral.
+There are a number of modes you can use. These are the available options.
 
-Default: `/srv/nfs-provisioner`
+| mode               | description                                                                                                                                                                                       | available settings                                                          |
+|--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
+| hostPath (default) | A hostPath volume mounts a file or directory from the host node’s filesystem into your pod  https://kubernetes.io/docs/concepts/storage/volumes/#hostpath                                         | * path: "/directory/location/on/host"    (defaults to /srv/nfs-provisioner) |
+| tmpFs              | mount a tmpfs (RAM-backed filesystem) instead of using the host node's storage or a PVC. This is very fast and very volatile but might be useful for things like caches and temporary workspaces. | none                                                                        |
+| emptyDir           | An emptyDir volume is first created when a Pod is assigned to a Node, and exists as long as that Pod is running on that node.  https://kubernetes.io/docs/concepts/storage/volumes/#emptydir      | none                                                                        |
+| pvc                | Make a Persistent Volume Claim for the nfs-provisioner.  https://kubernetes.io/docs/concepts/storage/persistent-volumes/                                                                          | * storageSize: "5Gi" (defaults to 1Gi)                                      |
 
-### `useTmpfs`
+To set a mode, set the `provisionerVolume.mode` value. For instance:
 
-If hostPath is empty and this is set to true, the NFS server will use memory-based
-tmpfs storage instead of allocating disk. This is very fast and very volatile, and
-has the additional risk of consuming cluster memory resources. It will not persist
-across a node restart.
+```console
+--set provisionerVolume.mode=pvc
+```
 
-Default: `false`
+To adjust settings, set the `provisionerVolume.settings.<setting_name>` value. For instance:
+
+```console
+--set provisionerVolume.settings.storageSize=5gi
+```
 
 ### `defaultClass`
 
 Whether to mark this storage provisioner as default. If set to `true`, unlabelled Persistent Volume Claims will use this provisioner.
 
 Default: `false`
+
+### `hostPath`
+
+**REMOVED**
+Please use the following configuration instead.
+
+```yaml
+provisionerVolume:
+  mode: "hostPath"
+```
+
+### `useTmpfs`
+
+**REMOVED**
+Please use the following configuration instead.
+
+```yaml
+provisionerVolume:
+  mode: "tmpFs"
+```
 
 ## TODO
 

--- a/charts/nfs-provisioner/Chart.yaml
+++ b/charts/nfs-provisioner/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: NFS server with PVC provisioner
 name: nfs-provisioner
-version: 0.2.0
+version: 0.3.0

--- a/charts/nfs-provisioner/templates/statefulset-sa.yaml
+++ b/charts/nfs-provisioner/templates/statefulset-sa.yaml
@@ -69,14 +69,31 @@ spec:
           volumeMounts:
             - name: export-volume
               mountPath: /export
+{{- if eq .Values.provisionerVolume.mode "pvc" }}
+  volumeClaimTemplates:
+  - metadata:
+      name: export-volume
+    spec:
+      accessModes:
+        - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: "{{ .Values.provisionerVolume.settings.storageSize | default "1Gi" }}"
+{{- else }}
       volumes:
         - name: export-volume
-{{ if .Values.hostPath }}
+{{- if eq .Values.provisionerVolume.mode "hostPath" }}
           hostPath:
-            path: "{{ .Values.hostPath }}"
-{{ else if .Values.useTmpfs }}
+            path: "{{ .Values.provisionerVolume.settings.path | default "/srv/nfs-provisioner" }}"
+{{ else if eq .Values.provisionerVolume.mode "useTmpFs" }}
           emptyDir:
             medium: Memory
-{{ else }}
+{{ else if eq .Values.provisionerVolume.mode "emptyDir" }}
           emptyDir: {}
 {{ end }}
+
+{{ end }}
+
+
+{{ if .Values.hostPath }}{{ fail "hostPath has been removed. please refer to the README for the migration path" }}{{end}}
+{{ if .Values.useTmpPath }}{{ fail "useTmpPath has been removed. please refer to the README for the migration path" }}{{end}}

--- a/charts/nfs-provisioner/values.yaml
+++ b/charts/nfs-provisioner/values.yaml
@@ -9,15 +9,38 @@ storageClass: "local-nfs"
 # Set the NFS provisioner to be the default storage class.
 defaultClass: false
 
-# If hostPath is empty, no hostPath volume is mounted. Instead, the server
-# is backed by an emptyDir.
-hostPath: "/srv/nfs-provisioner"
-
-# If hostPath is empty and this is true, the emptyDir will mount a tmpfs instead
-# of using local storage. This is vey fast and very volatile, but might be useful
-# for things like caches and temporary workspaces.
-useTmpfs: false
-
 # Toggle RBAC on and off
 rbac:
   enabled: true
+
+# There are serveral modes under which the nfs-provisioner logic can run.
+#
+# hostPath (default):
+#   A hostPath volume mounts a file or directory from the host node’s filesystem into your pod
+#   https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
+#   Available Settings:
+#     - path: /directory/location/on/host (defaults to /srv/nfs-provisioner)
+#
+# tmpFs:
+#   mount a tmpfs (RAM-backed filesystem) instead of using the host node's storage
+#   or a PVC. This is very fast and very volatile, but might be useful for things
+#   like caches and temporary workspaces.
+#   Available Settings:
+#     none
+#
+# emptyDir:
+#   An emptyDir volume is first created when a Pod is assigned to a Node, and
+#   exists as long as that Pod is running on that node.
+#   https://kubernetes.io/docs/concepts/storage/volumes/#emptydir
+#   Available Settings:
+#     none
+#
+# pvc:
+#   Make a Persistent Volume Claim for the nfs-provisioner.
+#   https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+#   Available Settings:
+#     - storageSize: 5Gi (defaults to 1Gi)
+provisionerVolume:
+  mode: "hostPath"
+  settings: {}
+  #   - foo: bar (see available settings for your mode above)


### PR DESCRIPTION
I needed this functionality and have tested it out on my cluster.

I'd like to unlock this functionality for others.

Please note that this would represent a breaking change for the chart. I'm curious to hear your thoughts on a breaking change. I'm new to writing helm charts, so there might be a way to support backwards compatibility here if we think it's really important. Feedback welcome!