### PR TITLE
Add mountOptions param to charts

### DIFF
--- a/charts/nfs-provisioner/templates/class.yaml
+++ b/charts/nfs-provisioner/templates/class.yaml
@@ -7,3 +7,6 @@ metadata:
     storageclass.kubernetes.io/is-default-class: "true"
   {{- end }}
 provisioner: "{{ .Values.provisionerName }}"
+parameters:
+  mountOptions: "vers=4.1"
+  

--- a/charts/nfs-provisioner/templates/class.yaml
+++ b/charts/nfs-provisioner/templates/class.yaml
@@ -9,4 +9,3 @@ metadata:
 provisioner: "{{ .Values.provisionerName }}"
 parameters:
   mountOptions: "vers=4.1"
-  


### PR DESCRIPTION
This fixes being unable to write to the PVC from a pod, as described in https://github.com/kubernetes-incubator/external-storage/issues/223#issuecomment-344972640